### PR TITLE
creation of new serverless templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "serverless-api-stage": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/serverless-api-stage/-/serverless-api-stage-1.4.0.tgz",
+      "integrity": "sha512-XSRrwwgGKzKG2bp1hlCHReDbGFYZ5spgmBN6c7lywwBcnpUOisosncv5JJMqXMo3nP1xgSFRtnh5+4gWK5rt3Q==",
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    }
+  }
+}

--- a/prod.serverless.yml
+++ b/prod.serverless.yml
@@ -1,0 +1,94 @@
+service: aws-rebuild-api
+
+plugins:
+  - serverless-api-stage
+
+provider:
+  name: aws
+  stage: Prod
+  runtime: dotnetcore3.1
+  region: eu-west-1
+  apiName: rebuild-api
+  apiGateway:
+    binaryMediaTypes:
+      - 'application/octet-stream'
+      - 'multipart/form-data'
+  logs:
+    restApi:
+      accessLogging: true
+      format: '$context.identity.sourceIp,$context.identity.caller,$context.identity.user,$context.requestTime,$context.httpMethod,$context.path,$context.protocol,$context.status,$context.responseLength,$context.requestId,$context.accountId'
+      fullExecutionData: false
+      role: arn:aws:iam::619711195898:role/apigateway-rebuild-cloudwatch
+
+package:
+  individually: true
+
+functions:
+  rebuild:
+    handler: Glasswall.CloudSdk.AWS.Rebuild::Glasswall.CloudSdk.AWS.Rebuild.LambdaEntryPoint::FunctionHandlerAsync
+    memorySize: 3008
+    timeout: 30
+    provisionedConcurrency: 3
+    events:
+      - http:
+          path: api/rebuild/base64
+          method: post
+          private: true
+          cors: true
+      - http:
+          path: api/rebuild/file
+          method: post
+          private: true
+          cors: true
+      - http:
+          path: api/rebuild
+          method: post
+          private: true
+          cors: true
+      - http:
+          path: api/health
+          method: get
+          private: false
+          cors: true
+    tags: 
+      PostUrl: Creating URL for base64
+
+    package:
+      artifact: Source/Service/bin/Release/netcoreapp3.1/Rebuild.zip
+
+custom:
+  stageSettings:
+    MethodSettings:
+      ThrottlingBurstLimit: 25
+      ThrottlingRateLimit: 50
+
+resources:
+  Resources:
+    GatewayResponseDefault4XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_4XX
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+    GatewayResponseDefault5XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_5XX
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+    GatewayResponseUnauthorized:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: UNAUTHORIZED
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+        StatusCode: '401'

--- a/prod_authorizer.serverless.yml
+++ b/prod_authorizer.serverless.yml
@@ -1,0 +1,105 @@
+service: aws-rebuild-api
+
+plugins:
+  - serverless-api-stage
+
+provider:
+  name: aws
+  stage: Prod
+  runtime: dotnetcore3.1
+  region: eu-west-1
+  apiName: rebuild-api-jwt
+  apiGateway:
+    binaryMediaTypes:
+      - 'application/octet-stream'
+      - 'multipart/form-data'
+  logs:
+    restApi:
+      accessLogging: true
+      format: '$context.identity.sourceIp,$context.identity.caller,$context.identity.user,$context.requestTime,$context.httpMethod,$context.path,$context.protocol,$context.status,$context.responseLength,$context.requestId,$context.accountId'
+      fullExecutionData: false
+      role: arn:aws:iam::619711195898:role/apigateway-rebuild-cloudwatch
+
+package:
+  individually: true
+
+functions:
+  rebuild:
+    handler: Glasswall.CloudSdk.AWS.Rebuild::Glasswall.CloudSdk.AWS.Rebuild.LambdaEntryPoint::FunctionHandlerAsync
+    memorySize: 3008
+    timeout: 30
+    provisionedConcurrency: 3
+    events:
+      - http:
+          path: api/rebuild/base64
+          method: post
+          cors: true
+          authorizer:
+            name: LambdaAuthorizer
+            arn: arn:aws:lambda:eu-west-1:619711195898:function:lambdaauthoriser-prod-executeLambdaAuthenticator
+            identitySource: method.request.header.Authorization       
+            type: request     
+      - http:
+          path: api/rebuild/file
+          method: post
+          cors: true
+          authorizer:
+            name: LambdaAuthorizer
+            arn: arn:aws:lambda:eu-west-1:619711195898:function:lambdaauthoriser-prod-executeLambdaAuthenticator
+            identitySource: method.request.header.Authorization       
+            type: request     
+      - http:
+          path: api/rebuild
+          method: post
+          cors: true
+          authorizer:
+            name: LambdaAuthorizer
+            arn: arn:aws:lambda:eu-west-1:619711195898:function:lambdaauthoriser-prod-executeLambdaAuthenticator
+            identitySource: method.request.header.Authorization       
+            type: request     
+      - http:
+          path: api/health
+          method: get
+          cors: true
+    tags: 
+      PostUrl: Creating URL for base64
+
+    package:
+      artifact: Source/Service/bin/Release/netcoreapp3.1/Rebuild.zip
+
+custom:
+  stageSettings:
+    MethodSettings:
+      ThrottlingBurstLimit: 25
+      ThrottlingRateLimit: 50
+
+resources:
+  Resources:
+    GatewayResponseDefault4XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_4XX
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+    GatewayResponseDefault5XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_5XX
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+    GatewayResponseUnauthorized:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: UNAUTHORIZED
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+        StatusCode: '401'

--- a/qa.serverless.yml
+++ b/qa.serverless.yml
@@ -1,0 +1,94 @@
+service: aws-rebuild-api
+
+plugins:
+  - serverless-api-stage
+
+provider:
+  name: aws
+  stage: QA
+  runtime: dotnetcore3.1
+  region: eu-west-1
+  apiName: rebuild-api
+  apiGateway:
+    binaryMediaTypes:
+      - 'application/octet-stream'
+      - 'multipart/form-data'
+  logs:
+    restApi:
+      accessLogging: true
+      format: '$context.identity.sourceIp,$context.identity.caller,$context.identity.user,$context.requestTime,$context.httpMethod,$context.path,$context.protocol,$context.status,$context.responseLength,$context.requestId,$context.accountId'
+      fullExecutionData: false
+      role: arn:aws:iam::461817386264:role/apigateway-rebuild-cloudwatch
+
+package:
+  individually: true
+
+functions:
+  rebuild:
+    handler: Glasswall.CloudSdk.AWS.Rebuild::Glasswall.CloudSdk.AWS.Rebuild.LambdaEntryPoint::FunctionHandlerAsync
+    memorySize: 3008
+    timeout: 30
+    provisionedConcurrency: 3
+    events:
+      - http:
+          path: api/rebuild/base64
+          method: post
+          private: true
+          cors: true
+      - http:
+          path: api/rebuild/file
+          method: post
+          private: true
+          cors: true
+      - http:
+          path: api/rebuild
+          method: post
+          private: true
+          cors: true
+      - http:
+          path: api/health
+          method: get
+          private: false
+          cors: true
+    tags: 
+      PostUrl: Creating URL for base64
+
+    package:
+      artifact: Source/Service/bin/Release/netcoreapp3.1/Rebuild.zip
+
+custom:
+  stageSettings:
+    MethodSettings:
+      ThrottlingBurstLimit: 25
+      ThrottlingRateLimit: 50
+
+resources:
+  Resources:
+    GatewayResponseDefault4XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_4XX
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+    GatewayResponseDefault5XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_5XX
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+    GatewayResponseUnauthorized:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: UNAUTHORIZED
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+        StatusCode: '401'

--- a/qa_authorizer.serverless.yml
+++ b/qa_authorizer.serverless.yml
@@ -1,20 +1,30 @@
 service: aws-rebuild-api
 
+plugins:
+  - serverless-api-stage
+
 provider:
   name: aws
+  stage: QA
   runtime: dotnetcore3.1
   region: eu-west-1
-  apiName: rebuild-api
+  apiName: rebuild-api-jwt
   apiGateway:
     binaryMediaTypes:
       - 'application/octet-stream'
       - 'multipart/form-data'
+  logs:
+    restApi:
+      accessLogging: true
+      format: '$context.identity.sourceIp,$context.identity.caller,$context.identity.user,$context.requestTime,$context.httpMethod,$context.path,$context.protocol,$context.status,$context.responseLength,$context.requestId,$context.accountId'
+      fullExecutionData: false
+      role: arn:aws:iam::461817386264:role/apigateway-rebuild-cloudwatch
 
 package:
   individually: true
 
 functions:
-  rebuild:
+  rebuild-jwt:
     handler: Glasswall.CloudSdk.AWS.Rebuild::Glasswall.CloudSdk.AWS.Rebuild.LambdaEntryPoint::FunctionHandlerAsync
     memorySize: 3008
     timeout: 30
@@ -23,28 +33,45 @@ functions:
       - http:
           path: api/rebuild/base64
           method: post
-          private: true
           cors: true
+          authorizer:
+            name: LambdaAuthorizer
+            arn: arn:aws:lambda:eu-west-1:461817386264:function:lambdaauthoriser-qa-executeLambdaAuthenticator
+            identitySource: method.request.header.Authorization       
+            type: request     
       - http:
           path: api/rebuild/file
           method: post
-          private: true
           cors: true
+          authorizer:
+            name: LambdaAuthorizer
+            arn: arn:aws:lambda:eu-west-1:461817386264:function:lambdaauthoriser-qa-executeLambdaAuthenticator
+            identitySource: method.request.header.Authorization       
+            type: request     
       - http:
           path: api/rebuild
           method: post
-          private: true
           cors: true
+          authorizer:
+            name: LambdaAuthorizer
+            arn: arn:aws:lambda:eu-west-1:461817386264:function:lambdaauthoriser-qa-executeLambdaAuthenticator
+            identitySource: method.request.header.Authorization       
+            type: request     
       - http:
           path: api/health
           method: get
-          private: false
           cors: true
     tags: 
       PostUrl: Creating URL for base64
 
     package:
       artifact: Source/Service/bin/Release/netcoreapp3.1/Rebuild.zip
+
+custom:
+  stageSettings:
+    MethodSettings:
+      ThrottlingBurstLimit: 25
+      ThrottlingRateLimit: 50
 
 resources:
   Resources:

--- a/stage.serverless.yml
+++ b/stage.serverless.yml
@@ -1,0 +1,94 @@
+service: aws-rebuild-api
+
+plugins:
+  - serverless-api-stage
+
+provider:
+  name: aws
+  stage: Staging
+  runtime: dotnetcore3.1
+  region: eu-west-1
+  apiName: rebuild-api
+  apiGateway:
+    binaryMediaTypes:
+      - 'application/octet-stream'
+      - 'multipart/form-data'
+  logs:
+    restApi:
+      accessLogging: true
+      format: '$context.identity.sourceIp,$context.identity.caller,$context.identity.user,$context.requestTime,$context.httpMethod,$context.path,$context.protocol,$context.status,$context.responseLength,$context.requestId,$context.accountId'
+      fullExecutionData: false
+      role: arn:aws:iam::582308720057:role/apigateway-rebuild-cloudwatch
+
+package:
+  individually: true
+
+functions:
+  rebuild:
+    handler: Glasswall.CloudSdk.AWS.Rebuild::Glasswall.CloudSdk.AWS.Rebuild.LambdaEntryPoint::FunctionHandlerAsync
+    memorySize: 3008
+    timeout: 30
+    provisionedConcurrency: 3
+    events:
+      - http:
+          path: api/rebuild/base64
+          method: post
+          private: true
+          cors: true
+      - http:
+          path: api/rebuild/file
+          method: post
+          private: true
+          cors: true
+      - http:
+          path: api/rebuild
+          method: post
+          private: true
+          cors: true
+      - http:
+          path: api/health
+          method: get
+          private: false
+          cors: true
+    tags: 
+      PostUrl: Creating URL for base64
+
+    package:
+      artifact: Source/Service/bin/Release/netcoreapp3.1/Rebuild.zip
+
+custom:
+  stageSettings:
+    MethodSettings:
+      ThrottlingBurstLimit: 25
+      ThrottlingRateLimit: 50
+
+resources:
+  Resources:
+    GatewayResponseDefault4XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_4XX
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+    GatewayResponseDefault5XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_5XX
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+    GatewayResponseUnauthorized:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: UNAUTHORIZED
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+        StatusCode: '401'

--- a/stage_authorizer.serverless.yml
+++ b/stage_authorizer.serverless.yml
@@ -1,0 +1,105 @@
+service: aws-rebuild-api
+
+plugins:
+  - serverless-api-stage
+
+provider:
+  name: aws
+  stage: Staging
+  runtime: dotnetcore3.1
+  region: eu-west-1
+  apiName: rebuild-api-jwt
+  apiGateway:
+    binaryMediaTypes:
+      - 'application/octet-stream'
+      - 'multipart/form-data'
+  logs:
+    restApi:
+      accessLogging: true
+      format: '$context.identity.sourceIp,$context.identity.caller,$context.identity.user,$context.requestTime,$context.httpMethod,$context.path,$context.protocol,$context.status,$context.responseLength,$context.requestId,$context.accountId'
+      fullExecutionData: false
+      role: arn:aws:iam::582308720057:role/apigateway-rebuild-cloudwatch
+
+package:
+  individually: true
+
+functions:
+  rebuild:
+    handler: Glasswall.CloudSdk.AWS.Rebuild::Glasswall.CloudSdk.AWS.Rebuild.LambdaEntryPoint::FunctionHandlerAsync
+    memorySize: 3008
+    timeout: 30
+    provisionedConcurrency: 3
+    events:
+      - http:
+          path: api/rebuild/base64
+          method: post
+          cors: true
+          authorizer:
+            name: LambdaAuthorizer
+            arn: arn:aws:lambda:eu-west-1:582308720057:function:lambdaauthoriser-stage-executeLambdaAuthenticator
+            identitySource: method.request.header.Authorization       
+            type: request     
+      - http:
+          path: api/rebuild/file
+          method: post
+          cors: true
+          authorizer:
+            name: LambdaAuthorizer
+            arn: arn:aws:lambda:eu-west-1:582308720057:function:lambdaauthoriser-stage-executeLambdaAuthenticator
+            identitySource: method.request.header.Authorization       
+            type: request     
+      - http:
+          path: api/rebuild
+          method: post
+          cors: true
+          authorizer:
+            name: LambdaAuthorizer
+            arn: arn:aws:lambda:eu-west-1:582308720057:function:lambdaauthoriser-stage-executeLambdaAuthenticator
+            identitySource: method.request.header.Authorization       
+            type: request     
+      - http:
+          path: api/health
+          method: get
+          cors: true
+    tags: 
+      PostUrl: Creating URL for base64
+
+    package:
+      artifact: Source/Service/bin/Release/netcoreapp3.1/Rebuild.zip
+
+custom:
+  stageSettings:
+    MethodSettings:
+      ThrottlingBurstLimit: 25
+      ThrottlingRateLimit: 50      
+
+resources:
+  Resources:
+    GatewayResponseDefault4XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_4XX
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+    GatewayResponseDefault5XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_5XX
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+    GatewayResponseUnauthorized:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: UNAUTHORIZED
+        RestApiId: 
+          Ref: 'ApiGatewayRestApi'
+        StatusCode: '401'


### PR DESCRIPTION
Additional Serverless Templates added:
- 3x versions which use Api Management as the Authorizer
- 3x versions which use standard api keys

Had to have separate versions of each as the ARN needed to be specified for Logging and Authorizer

Updates include addition of default Burst and Limit settings, addition of Logging by the api gateways for use in DataDog

closes #61 closes #62 closes #63 closes #64 closes #65 